### PR TITLE
fixed _profile

### DIFF
--- a/webui/src/page/ServerProfilePage.tsx
+++ b/webui/src/page/ServerProfilePage.tsx
@@ -150,7 +150,7 @@ const Page: Component = () => {
 
         const resolved = new URL(path, indexUrl).pathname  
         const profileRootPath = new URL(profileRoot).pathname  
-        if (!resolved.startsWith(profileRootPath))
+        if (!resolved.startsWith(profileRootPath)) {
 					return (
 						<div>
 							<p>Profile contains invalid paths.</p>

--- a/webui/src/page/ServerProfilePage.tsx
+++ b/webui/src/page/ServerProfilePage.tsx
@@ -148,8 +148,9 @@ const Page: Component = () => {
 					)
 				}
 
-				const resolved = (new URL(path, window.location.origin)).pathname
-				if (!resolved.startsWith(profileRoot)) {
+        const resolved = new URL(path, indexUrl).pathname  
+        const profileRootPath = new URL(profileRoot).pathname  
+        if (!resolved.startsWith(profileRootPath))
 					return (
 						<div>
 							<p>Profile contains invalid paths.</p>


### PR DESCRIPTION
#12 the issue was that profileRoot on line 18: `const profileRoot = makeFileUrl(fsUrl, uuid, username, '/_profile') ` 
is a full URL returned by `makeFileUrl` but resolved is only the `.pathname` of a url resolved against `window.location.origin` thus a pathname like `/image.png` can never start with a full url from a different origin.
so you have to resolve the `path` against `indexUrl`  and compare `.pathname` of `profileRoot`.




Note: might have used the code highlight thing a bit too much, and yapped too.

another note: this whole check is kinda of lacking and has a lot of issues i would suggest either removing it or doing a lot of fixing 