### PR TITLE
Fix the self-connect bug

### DIFF
--- a/client/direct/server.go
+++ b/client/direct/server.go
@@ -244,7 +244,7 @@ func (s *Server) connHandler(conn protocol.ProtoConn) {
 		)
 	}
 
-	msg, err := protocol.ReadExpect[*pb.MsgDirectConnHandshake](bidi.ProtoStreamReader, pb.MsgType_MSG_TYPE_DIRECT_CONN_HANDSHAKE)
+	msg, err := protocol.ReadExpect[*pb.MsgDirectConnHandshake](bidi, pb.MsgType_MSG_TYPE_DIRECT_CONN_HANDSHAKE)
 	if err != nil {
 		var streamErr *quic.StreamError
 		if protocol.IsErrorConnCloseOrCancel(err) ||

--- a/client/room/c2c.go
+++ b/client/room/c2c.go
@@ -13,7 +13,7 @@ import (
 // C2cBidi is a client-to-client bidi stream
 type C2cBidi struct {
 	// The function to disown the connection.
-	// Should be nil if from a proxy.
+	// Should be nil if from a proxy or loopback.
 	disown func()
 
 	protocol.ProtoBidi

--- a/client/room/conn.go
+++ b/client/room/conn.go
@@ -541,7 +541,7 @@ func (c *Conn) openC2cBidiWithMsg(
 			_ = bidi.Close()
 			return protocol.ProtoBidi{}, err
 		}
-		ctmRes, err := protocol.ReadExpect[*pb.MsgDirectConnResult](bidi.ProtoStreamReader, pb.MsgType_MSG_TYPE_DIRECT_CONN_RESULT)
+		ctmRes, err := protocol.ReadExpect[*pb.MsgDirectConnResult](bidi, pb.MsgType_MSG_TYPE_DIRECT_CONN_RESULT)
 		if err != nil {
 			if c.isErrProxyPeerUnreachable(err) {
 				return protocol.ProtoBidi{}, protocol.ErrPeerUnreachable

--- a/client/room/logic.go
+++ b/client/room/logic.go
@@ -286,7 +286,7 @@ func (l *LogicImpl) OnGetFile(_ context.Context, _ *Conn, bidi C2cBidi, msg *pro
 		return nil
 	}
 
-	_, err = io.Copy(bidi.ProtoBidi.Stream, reader)
+	_, err = io.Copy(bidi.ProtoBidi.RawWriter(), reader)
 	if err != nil {
 		if _, is := errors.AsType[*quic.StreamError](err); is {
 			// If the other side closed, we can just quit.

--- a/client/room/virtualc2c.go
+++ b/client/room/virtualc2c.go
@@ -59,6 +59,19 @@ func (c VirtualC2cConn) OpenBidiWithMsg(typ pb.MsgType, msg proto.Message) (bidi
 		return
 	}
 
+	// If C2C points to ourselves, return a loopback bidi stream.
+	if c.Username == c.ServerConn.Username {
+		bidi1, bidi2 := protocol.NewPipeProtoBidi()
+		c.ServerConn.incomingBidi <- C2cBidi{
+			ProtoBidi: bidi2,
+			RoomConn:  c.ServerConn,
+			Username:  c.Username,
+		}
+
+		return bidi1, bidi1.Write(typ, msg)
+	}
+
+	// Do a normal C2C message.
 	return c.ServerConn.openC2cBidiWithMsg(c.Username, typ, msg, c.ForceProxy)
 }
 
@@ -142,7 +155,7 @@ func (c VirtualC2cConn) GetFile(req *pb.MsgGetFile) (meta *pb.MsgFileMeta, reade
 	}
 
 	msg, err := protocol.ReadExpect[*pb.MsgFileMeta](
-		bidi.ProtoStreamReader,
+		bidi,
 		pb.MsgType_MSG_TYPE_FILE_META,
 	)
 	if err != nil {
@@ -151,7 +164,7 @@ func (c VirtualC2cConn) GetFile(req *pb.MsgGetFile) (meta *pb.MsgFileMeta, reade
 
 	// Now that we have the metadata, we can treat the bidi as a binary stream.
 	reader = common.NewLimitReadCloser(
-		protocol.NewReadCloserWithFunc(bidi.Stream, bidi.Close),
+		protocol.NewReadCloserWithFunc(bidi.RawReader(), bidi.Close),
 		int64(msg.Payload.Size),
 	)
 	return msg.Payload, reader, nil

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -90,6 +90,130 @@ func ToTyped[T proto.Message](msg *UntypedProtoMsg) *TypedProtoMsg[T] {
 	return NewTypedProtoMsg(msg.Type, casted)
 }
 
+// ReadProtoMessage reads a protocol message from an io.Reader.
+func ReadProtoMessage(r io.Reader) (*UntypedProtoMsg, error) {
+	var (
+		n   int
+		err error
+	)
+
+	// Read header.
+	// A tiny read like this is fine because QUIC streams are buffered.
+	var header [msgHeaderSize]byte
+	headerRead := 0
+	for headerRead < len(header) {
+		n, err = r.Read(header[headerRead:])
+		if n > 0 {
+			headerRead += n
+		}
+		if err != nil {
+			var streamErr *quic.StreamError
+			if errors.As(err, &streamErr) {
+				if streamErr.ErrorCode == ProxyPeerUnreachableStreamErrorCode {
+					return nil, ErrPeerUnreachable
+				}
+			}
+
+			if errors.Is(err, io.EOF) && headerRead == len(header) {
+				break
+			}
+			return nil, fmt.Errorf(`failed to read protocol message header: %w`, err)
+		}
+	}
+
+	typ := pb.MsgType(binary.LittleEndian.Uint32(header[:4]))
+	payloadLen := binary.LittleEndian.Uint32(header[4:])
+
+	if payloadLen > MaxPayloadSize {
+		return nil, fmt.Errorf(`got protocol message header with type %s and length %d, but payload size exceeds maximum allowed %d`, typ.String(), payloadLen, MaxPayloadSize)
+	}
+
+	// Read payload.
+	readSize := 0
+	payload := make([]byte, payloadLen)
+	for readSize < len(payload) {
+		n, err = r.Read(payload[readSize:])
+		if n > 0 {
+			readSize += n
+		}
+		if err != nil {
+			if err == io.EOF && readSize == len(payload) {
+				break
+			}
+			return nil, fmt.Errorf(`got protocol message header with type %s and length %d, but failed reading payload at %d bytes: %w`,
+				typ.String(),
+				payloadLen,
+				readSize,
+				err,
+			)
+		}
+	}
+
+	// Decode message.
+	msg := MsgTypeToEmptyMsg(typ)
+	if msg == nil {
+		return nil, fmt.Errorf(`BUG: got message type %s but there was no message mapping for it`, typ.String())
+	}
+
+	err = proto.Unmarshal(payload, msg)
+	if err != nil {
+		return nil, fmt.Errorf(`failed to decode protocol message payload with supposed type %s and length %d: %w`,
+			typ.String(),
+			payloadLen,
+			err,
+		)
+	}
+
+	return &UntypedProtoMsg{
+		Type:    typ,
+		Payload: msg,
+	}, nil
+}
+
+// WriteProtoMessage writes a protocol message to an io.Writer.
+func WriteProtoMessage(w io.Writer, typ pb.MsgType, msg proto.Message) error {
+	msgSize := proto.Size(msg)
+	msgBuf := make([]byte, msgHeaderSize, msgHeaderSize+msgSize)
+
+	// Write header.
+	binary.LittleEndian.PutUint32(msgBuf[:4], uint32(typ))
+	binary.LittleEndian.PutUint32(msgBuf[4:8], uint32(msgSize))
+
+	// Marshal and append payload.
+	var err error
+	msgBuf, err = proto.MarshalOptions{}.MarshalAppend(msgBuf, msg)
+	if err != nil {
+		return fmt.Errorf(`failed to marshal payload for message with type %s: %w`,
+			typ.String(),
+			err,
+		)
+	}
+
+	// Write message.
+	written := 0
+	for written < len(msgBuf) {
+		n, err := w.Write(msgBuf[written:])
+		if err != nil {
+			var streamErr *quic.StreamError
+			if errors.As(err, &streamErr) {
+				if streamErr.ErrorCode == ProxyPeerUnreachableStreamErrorCode {
+					return ErrPeerUnreachable
+				}
+			}
+
+			return fmt.Errorf(`failed to write payload for message type %s while %d bytes in: %w`,
+				typ.String(),
+				written,
+				err,
+			)
+		}
+
+		written += n
+	}
+
+	return nil
+}
+
 // ProtoDialer is a dialer that can return protocol connections.
 type ProtoDialer interface {
 	io.Closer
@@ -232,7 +356,7 @@ func (conn *ProtoConnImpl) OpenBidiWithMsg(typ pb.MsgType, msg proto.Message) (b
 		return ProtoBidi{}, fmt.Errorf(`failed to open bidi before writing message of type %s: %w`, typ.String(), err)
 	}
 
-	bidi = wrapBidi(stream)
+	bidi = NewQuicProtoBidi(stream)
 
 	err = bidi.Write(typ, msg)
 	if err != nil {
@@ -251,7 +375,7 @@ func (conn *ProtoConnImpl) WaitForBidi(ctx context.Context) (ProtoBidi, error) {
 		return ProtoBidi{}, fmt.Errorf(`failed to accept stream in WaitForBidi: %w`, err)
 	}
 
-	return wrapBidi(stream), nil
+	return NewQuicProtoBidi(stream), nil
 }
 
 func (conn *ProtoConnImpl) SendAndReceive(typ pb.MsgType, msg proto.Message) (*UntypedProtoMsg, error) {
@@ -296,36 +420,13 @@ func SendAndReceiveExpect[T proto.Message](
 	msg proto.Message,
 	expectType pb.MsgType,
 ) (*TypedProtoMsg[T], error) {
-	reply, err := conn.SendAndReceive(typ, msg)
+	bidi, err := conn.OpenBidiWithMsg(typ, msg)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = bidi.Close() }()
 
-	if reply.Type != expectType {
-		return nil, NewUnexpectedMsgTypeError(
-			expectType,
-			reply.Type,
-			reply.Payload,
-		)
-	}
-
-	casted, ok := reply.Payload.(T)
-	if !ok {
-		wantType := reflect.TypeFor[T]()
-		gotType := reflect.TypeOf(msg)
-
-		panic(fmt.Sprintf(`BUG: got message of type %s (struct %s) as reply to new bidi with message type %s but tried to cast it to struct %s`,
-			reply.Type.String(),
-			gotType.String(),
-			typ.String(),
-			wantType.String(),
-		))
-	}
-
-	return &TypedProtoMsg[T]{
-		Type:    reply.Type,
-		Payload: casted,
-	}, nil
+	return ReadExpect[T](bidi, expectType)
 }
 
 type BidiHandler func(conn *quic.Conn, bidi ProtoBidi, msg *UntypedProtoMsg) error
@@ -347,82 +448,7 @@ func NewProtoStreamReader(stream io.Reader) *ProtoStreamReader {
 // It does not do any special handling for error types.
 // If the bidi was closed because a remote peer was unreachable, returns ErrPeerUnreachable.
 func (r *ProtoStreamReader) ReadRaw() (*UntypedProtoMsg, error) {
-	var (
-		n   int
-		err error
-	)
-
-	// Read header.
-	// A tiny read like this is fine because QUIC streams are buffered.
-	var header [msgHeaderSize]byte
-	headerRead := 0
-	for headerRead < len(header) {
-		n, err = r.stream.Read(header[headerRead:])
-		if n > 0 {
-			headerRead += n
-		}
-		if err != nil {
-			var streamErr *quic.StreamError
-			if errors.As(err, &streamErr) {
-				if streamErr.ErrorCode == ProxyPeerUnreachableStreamErrorCode {
-					return nil, ErrPeerUnreachable
-				}
-			}
-
-			if errors.Is(err, io.EOF) && headerRead == len(header) {
-				break
-			}
-			return nil, fmt.Errorf(`failed to read protocol message header: %w`, err)
-		}
-	}
-
-	typ := pb.MsgType(binary.LittleEndian.Uint32(header[:4]))
-	payloadLen := binary.LittleEndian.Uint32(header[4:])
-
-	if payloadLen > MaxPayloadSize {
-		return nil, fmt.Errorf(`got protocol message header with type %s and length %d, but payload size exceeds maximum allowed %d`, typ.String(), payloadLen, MaxPayloadSize)
-	}
-
-	// Read payload.
-	readSize := 0
-	payload := make([]byte, payloadLen)
-	for readSize < len(payload) {
-		n, err = r.stream.Read(payload[readSize:])
-		if n > 0 {
-			readSize += n
-		}
-		if err != nil {
-			if err == io.EOF && readSize == len(payload) {
-				break
-			}
-			return nil, fmt.Errorf(`got protocol message header with type %s and length %d, but failed reading payload at %d bytes: %w`,
-				typ.String(),
-				payloadLen,
-				readSize,
-				err,
-			)
-		}
-	}
-
-	// Decode message.
-	msg := MsgTypeToEmptyMsg(typ)
-	if msg == nil {
-		return nil, fmt.Errorf(`BUG: got message type %s but there was no message mapping for it`, typ.String())
-	}
-
-	err = proto.Unmarshal(payload, msg)
-	if err != nil {
-		return nil, fmt.Errorf(`failed to decode protocol message payload with supposed type %s and length %d: %w`,
-			typ.String(),
-			payloadLen,
-			err,
-		)
-	}
-
-	return &UntypedProtoMsg{
-		Type:    typ,
-		Payload: msg,
-	}, nil
+	return ReadProtoMessage(r.stream)
 }
 
 // ReadRaw tries to read a protocol message from the stream.
@@ -450,7 +476,7 @@ func (r *ProtoStreamReader) Read() (*UntypedProtoMsg, error) {
 //
 // It is extremely important that the generic type on this function is appropriate for the expected type.
 // If the generic type does not correspond to the expected type, the function will panic.
-func ReadExpect[T proto.Message](r *ProtoStreamReader, expectedType pb.MsgType) (*TypedProtoMsg[T], error) {
+func ReadExpect[T proto.Message](r ProtoBidi, expectedType pb.MsgType) (*TypedProtoMsg[T], error) {
 	msg, err := r.Read()
 	if err != nil {
 		return nil, err
@@ -494,78 +520,17 @@ func NewProtoStreamWriter(stream io.Writer) *ProtoStreamWriter {
 
 // Write tries to write a protocol message to the stream.
 func (w *ProtoStreamWriter) Write(typ pb.MsgType, msg proto.Message) error {
-	msgSize := proto.Size(msg)
-	msgBuf := make([]byte, msgHeaderSize, msgHeaderSize+msgSize)
-
-	// Write header.
-	binary.LittleEndian.PutUint32(msgBuf[:4], uint32(typ))
-	binary.LittleEndian.PutUint32(msgBuf[4:8], uint32(msgSize))
-
-	// Marshal and append payload.
-	var err error
-	msgBuf, err = proto.MarshalOptions{}.MarshalAppend(msgBuf, msg)
-	if err != nil {
-		return fmt.Errorf(`failed to marshal payload for message with type %s: %w`,
-			typ.String(),
-			err,
-		)
-	}
-
-	// Write message.
-	written := 0
-	for written < len(msgBuf) {
-		n, err := w.stream.Write(msgBuf[written:])
-		if err != nil {
-			var streamErr *quic.StreamError
-			if errors.As(err, &streamErr) {
-				if streamErr.ErrorCode == ProxyPeerUnreachableStreamErrorCode {
-					return ErrPeerUnreachable
-				}
-			}
-
-			return fmt.Errorf(`failed to write payload for message type %s while %d bytes in: %w`,
-				typ.String(),
-				written,
-				err,
-			)
-		}
-
-		written += n
-	}
-
-	return nil
-}
-
-// ProtoBidi is a wrapper around a QUIC bidirectional stream with a protocol reader and writer.
-type ProtoBidi struct {
-	Stream *quic.Stream
-	*ProtoStreamReader
-	*ProtoStreamWriter
-}
-
-// Close closes the send side and cancels the read side to fully release the stream.
-func (bidi ProtoBidi) Close() error {
-	_ = bidi.Stream.Close()
-	bidi.Stream.CancelRead(0)
-	return nil
-}
-
-func wrapBidi(stream *quic.Stream) ProtoBidi {
-	return ProtoBidi{
-		Stream:            stream,
-		ProtoStreamReader: NewProtoStreamReader(stream),
-		ProtoStreamWriter: NewProtoStreamWriter(stream),
-	}
+	return WriteProtoMessage(w.stream, typ, msg)
 }
 
 // WriteAck writes an acknowledgement message to the bidi stream.
-func (bidi ProtoBidi) WriteAck() error {
+func (bidi *ProtoStreamWriter) WriteAck() error {
 	return bidi.Write(pb.MsgType_MSG_TYPE_ACKNOWLEDGED, &pb.MsgAcknowledged{})
 }
 
 // WriteError writes an error message to the bidi stream.
 // If the message is empty, it will be sent as nil.
-func (bidi ProtoBidi) WriteError(typ pb.ErrType, msg string) error {
+func (bidi *ProtoStreamWriter) WriteError(typ pb.ErrType, msg string) error {
 	return bidi.Write(pb.MsgType_MSG_TYPE_ERROR, &pb.MsgError{
 		Type:    typ,
 		Message: common.StrOrNil(msg),
@@ -574,7 +539,7 @@ func (bidi ProtoBidi) WriteError(typ pb.ErrType, msg string) error {
 
 // WriteClientNotOnlineError writes an ERR_TYPE_CLIENT_NOT_ONLINE error to the bidi stream,
 // based on the specified username.
-func (bidi ProtoBidi) WriteClientNotOnlineError(username common.NormalizedUsername) error {
+func (bidi *ProtoStreamWriter) WriteClientNotOnlineError(username common.NormalizedUsername) error {
 	return bidi.WriteError(pb.ErrType_ERR_TYPE_CLIENT_NOT_ONLINE,
 		"client "+username.String()+" is not online",
 	)
@@ -582,13 +547,13 @@ func (bidi ProtoBidi) WriteClientNotOnlineError(username common.NormalizedUserna
 
 // WriteFileNotExistError writes an ERR_TYPE_FILE_NOT_EXIST error to the bidi stream,
 // based on the specified path.
-func (bidi ProtoBidi) WriteFileNotExistError(path string) error {
+func (bidi *ProtoStreamWriter) WriteFileNotExistError(path string) error {
 	return bidi.WriteError(pb.ErrType_ERR_TYPE_FILE_NOT_EXIST, fmt.Sprintf("no such path %q", path))
 }
 
 // WriteUnexpectedMsgTypeError writes an ERR_TYPE_UNEXPECTED_MSG_TYPE error to the bidi stream,
 // based on the specified expected and actual message types.
-func (bidi ProtoBidi) WriteUnexpectedMsgTypeError(expected pb.MsgType, actual pb.MsgType) error {
+func (bidi *ProtoStreamWriter) WriteUnexpectedMsgTypeError(expected pb.MsgType, actual pb.MsgType) error {
 	return bidi.WriteError(
 		pb.ErrType_ERR_TYPE_UNEXPECTED_MSG_TYPE,
 		fmt.Sprintf("expected %s but got %s", expected.String(), actual.String()),
@@ -597,7 +562,7 @@ func (bidi ProtoBidi) WriteUnexpectedMsgTypeError(expected pb.MsgType, actual pb
 
 // WriteInternalError writes an ERR_TYPE_INTERNAL error to the bidi stream.
 // Uses the error message from the specified error, or a placeholder if it is nil.
-func (bidi ProtoBidi) WriteInternalError(errOrNil error) error {
+func (bidi *ProtoStreamWriter) WriteInternalError(errOrNil error) error {
 	var message string
 	if errOrNil == nil {
 		message = "internal error"
@@ -609,11 +574,79 @@ func (bidi ProtoBidi) WriteInternalError(errOrNil error) error {
 
 // WriteUnimplementedError writes an ERR_TYPE_UNIMPLEMENTED error to the bidi stream,
 // based on the specified message type.
-func (bidi ProtoBidi) WriteUnimplementedError(msgType pb.MsgType) error {
+func (bidi *ProtoStreamWriter) WriteUnimplementedError(msgType pb.MsgType) error {
 	return bidi.WriteError(
 		pb.ErrType_ERR_TYPE_UNIMPLEMENTED,
 		fmt.Sprintf("handler for %q is unimplemented", msgType.String()),
 	)
+}
+
+// ProtoBidi is a bidirection protocol message stream.
+// It can also expose its raw byte reader and writer.
+type ProtoBidi struct {
+	close  func() error
+	reader io.Reader
+	writer io.Writer
+	*ProtoStreamReader
+	*ProtoStreamWriter
+}
+
+// RawReader returns the bidi's raw byte reader.
+func (bidi ProtoBidi) RawReader() io.Reader {
+	return bidi.reader
+}
+
+// RawWriter returns the bidi's raw byte writer.
+func (bidi ProtoBidi) RawWriter() io.Writer {
+	return bidi.writer
+}
+
+// Close closes the send side and cancels the read side to fully release the stream.
+func (bidi ProtoBidi) Close() error {
+	return bidi.close()
+}
+
+// NewQuicProtoBidi creates a new ProtoBidi from a QUIC bidirectional stream.
+func NewQuicProtoBidi(stream *quic.Stream) ProtoBidi {
+	return ProtoBidi{
+		close: func() error {
+			stream.CancelRead(0)
+			stream.CancelWrite(0)
+			return stream.Close()
+		},
+		reader:            stream,
+		writer:            stream,
+		ProtoStreamReader: NewProtoStreamReader(stream),
+		ProtoStreamWriter: NewProtoStreamWriter(stream),
+	}
+}
+
+// NewPipeProtoBidi creates two new ProtoBidi objects with swapped reader/writers to emulate loopback messaging
+func NewPipeProtoBidi() (ProtoBidi, ProtoBidi) {
+	r1, w1 := io.Pipe()
+	r2, w2 := io.Pipe()
+
+	return ProtoBidi{
+			close: func() error {
+				_ = r1.Close()
+				_ = w2.Close()
+				return nil
+			},
+			reader:            r1,
+			writer:            w2,
+			ProtoStreamReader: NewProtoStreamReader(r1),
+			ProtoStreamWriter: NewProtoStreamWriter(w2),
+		}, ProtoBidi{
+			close: func() error {
+				_ = r2.Close()
+				_ = w1.Close()
+				return nil
+			},
+			reader:            r2,
+			writer:            w1,
+			ProtoStreamReader: NewProtoStreamReader(r2),
+			ProtoStreamWriter: NewProtoStreamWriter(w1),
+		}
 }
 
 // CompareProtoVersions compares two protocol versions.

--- a/protocol/stream.go
+++ b/protocol/stream.go
@@ -36,7 +36,7 @@ func NewTypedMsgStream[T proto.Message](reader ProtoBidi, typ pb.MsgType) TypedM
 // ReadNext reads the next message from the stream.
 // If the stream has ended, returns io.EOF.
 func (s TypedMsgStream[T]) ReadNext() (*TypedProtoMsg[T], error) {
-	msg, err := ReadExpect[T](s.bidi.ProtoStreamReader, s.typ)
+	msg, err := ReadExpect[T](s.bidi, s.typ)
 	if err != nil {
 		var streamErr *quic.StreamError
 		if errors.As(err, &streamErr) ||

--- a/server/lobby/lobby.go
+++ b/server/lobby/lobby.go
@@ -204,7 +204,7 @@ func (l *Lobby) negotiateClientVersion(
 func (l *Lobby) authenticateClient(
 	ctx context.Context,
 	conn protocol.ProtoConn,
-) (authBidi protocol.ProtoBidi, room common.NormalizedRoomName, username common.NormalizedUsername, finalErr error) {
+) (authBidi protocol.QuicProtoBidi, room common.NormalizedRoomName, username common.NormalizedUsername, finalErr error) {
 	isSuccess := false
 	var bidiErr error
 	authBidi, bidiErr = conn.WaitForBidi(ctx)

--- a/server/room/client.go
+++ b/server/room/client.go
@@ -63,7 +63,7 @@ func NewClient(
 // msgHandler handles a message from a client.
 // It must not close the bidi passed to it.
 // After returning, the bidi will be closed.
-func (c *Client) msgHandler(bidi protocol.ProtoBidi, firstMsg *protocol.UntypedProtoMsg) error {
+func (c *Client) msgHandler(bidi protocol.QuicProtoBidi, firstMsg *protocol.UntypedProtoMsg) error {
 	ctx := context.Background()
 
 	switch firstMsg.Type {
@@ -114,7 +114,7 @@ func (c *Client) msgHandler(bidi protocol.ProtoBidi, firstMsg *protocol.UntypedP
 // bidiHandler handles a new C2S bidi.
 // It must not close the bidi passed to it.
 // After returning, the bidi will be closed.
-func (c *Client) bidiHandler(bidi protocol.ProtoBidi) {
+func (c *Client) bidiHandler(bidi protocol.QuicProtoBidi) {
 	// Read first message.
 	firstMsg, firstErr := bidi.Read()
 	if firstErr != nil {

--- a/server/room/logic.go
+++ b/server/room/logic.go
@@ -27,7 +27,7 @@ type Logic interface {
 	OnPing(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgPing],
 	) error
 
@@ -36,7 +36,7 @@ type Logic interface {
 	OnOpenOutboundProxy(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgOpenOutboundProxy],
 	) error
 
@@ -45,7 +45,7 @@ type Logic interface {
 	OnGetOnlineUsers(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetOnlineUsers],
 	) error
 
@@ -54,7 +54,7 @@ type Logic interface {
 	OnAdvertiseConnMethod(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgAdvertiseConnMethod],
 	) error
 
@@ -63,7 +63,7 @@ type Logic interface {
 	OnRemoveConnMethod(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgRemoveConnMethod],
 	) error
 
@@ -72,7 +72,7 @@ type Logic interface {
 	OnGetPublicIp(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetPublicIp],
 	) error
 
@@ -81,7 +81,7 @@ type Logic interface {
 	OnGetClientConnMethods(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetClientConnMethods],
 	) error
 
@@ -90,7 +90,7 @@ type Logic interface {
 	OnGetDirectConnHandshakeToken(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetDirectConnHandshakeToken],
 	) error
 
@@ -99,7 +99,7 @@ type Logic interface {
 	OnRedeemConnHandshakeToken(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgRedeemConnHandshakeToken],
 	) error
 
@@ -108,7 +108,7 @@ type Logic interface {
 	OnChangeAccountPassword(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgChangeAccountPassword],
 	) error
 
@@ -117,14 +117,14 @@ type Logic interface {
 	OnSearch(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgSearch],
 	) error
 
 	OnGetStunServers(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.ProtoBidi,
+		bidi protocol.QuicProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetStunServers],
 	) error
 }
@@ -155,13 +155,13 @@ func NewLogicImpl(
 	}
 }
 
-func (l LogicImpl) OnPing(_ context.Context, _ *Client, bidi protocol.ProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgPing]) error {
+func (l LogicImpl) OnPing(_ context.Context, _ *Client, bidi protocol.QuicProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgPing]) error {
 	return bidi.Write(pb.MsgType_MSG_TYPE_PONG, &pb.MsgPong{
 		SentTs: time.Now().Unix(),
 	})
 }
 
-func (l LogicImpl) OnOpenOutboundProxy(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgOpenOutboundProxy]) error {
+func (l LogicImpl) OnOpenOutboundProxy(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgOpenOutboundProxy]) error {
 	// Validate username.
 	targetUsername, usernameValid := common.NormalizeUsername(msg.Payload.TargetUsername)
 	if !usernameValid {
@@ -189,7 +189,7 @@ func (l LogicImpl) OnOpenOutboundProxy(_ context.Context, client *Client, bidi p
 	return proxy.Run()
 }
 
-func (l LogicImpl) OnGetOnlineUsers(_ context.Context, client *Client, bidi protocol.ProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetOnlineUsers]) error {
+func (l LogicImpl) OnGetOnlineUsers(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetOnlineUsers]) error {
 	const pageSize = 50
 
 	// Snapshot clients and get their statuses.
@@ -223,7 +223,7 @@ func (l LogicImpl) OnGetOnlineUsers(_ context.Context, client *Client, bidi prot
 	return nil
 }
 
-func (l LogicImpl) OnAdvertiseConnMethod(ctx context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgAdvertiseConnMethod]) error {
+func (l LogicImpl) OnAdvertiseConnMethod(ctx context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgAdvertiseConnMethod]) error {
 	ad := msg.Payload
 
 	// Validate address.
@@ -321,7 +321,7 @@ func (l LogicImpl) OnAdvertiseConnMethod(ctx context.Context, client *Client, bi
 	return nil
 }
 
-func (l LogicImpl) OnRemoveConnMethod(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgRemoveConnMethod]) error {
+func (l LogicImpl) OnRemoveConnMethod(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgRemoveConnMethod]) error {
 	client.mu.Lock()
 	_, has := client.connMethods[msg.Payload.Id]
 	if !has {
@@ -334,7 +334,7 @@ func (l LogicImpl) OnRemoveConnMethod(_ context.Context, client *Client, bidi pr
 	return bidi.WriteAck()
 }
 
-func (l LogicImpl) OnGetPublicIp(_ context.Context, client *Client, bidi protocol.ProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetPublicIp]) error {
+func (l LogicImpl) OnGetPublicIp(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetPublicIp]) error {
 	remote := client.RemoteAddr().String()
 
 	var addr string
@@ -349,7 +349,7 @@ func (l LogicImpl) OnGetPublicIp(_ context.Context, client *Client, bidi protoco
 	})
 }
 
-func (l LogicImpl) OnGetClientConnMethods(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgGetClientConnMethods]) error {
+func (l LogicImpl) OnGetClientConnMethods(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgGetClientConnMethods]) error {
 	username, usernameOk := common.NormalizeUsername(msg.Payload.Username)
 	if !usernameOk {
 		return bidi.WriteError(pb.ErrType_ERR_TYPE_INVALID_FIELDS, "invalid username")
@@ -365,7 +365,7 @@ func (l LogicImpl) OnGetClientConnMethods(_ context.Context, client *Client, bid
 	})
 }
 
-func (l LogicImpl) OnGetDirectConnHandshakeToken(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgGetDirectConnHandshakeToken]) error {
+func (l LogicImpl) OnGetDirectConnHandshakeToken(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgGetDirectConnHandshakeToken]) error {
 	target, usernameOk := common.NormalizeUsername(msg.Payload.Username)
 	if !usernameOk {
 		return bidi.WriteError(pb.ErrType_ERR_TYPE_INVALID_FIELDS, "invalid target username")
@@ -379,14 +379,14 @@ func (l LogicImpl) OnGetDirectConnHandshakeToken(_ context.Context, client *Clie
 	})
 }
 
-func (l LogicImpl) OnRedeemConnHandshakeToken(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgRedeemConnHandshakeToken]) error {
+func (l LogicImpl) OnRedeemConnHandshakeToken(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgRedeemConnHandshakeToken]) error {
 	return bidi.Write(
 		pb.MsgType_MSG_TYPE_REDEEM_CONN_HANDSHAKE_TOKEN_RESULT,
 		client.Room.TokenManager.Redeem(client.Username, msg.Payload.Token),
 	)
 }
 
-func (l LogicImpl) OnChangeAccountPassword(ctx context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgChangeAccountPassword]) error {
+func (l LogicImpl) OnChangeAccountPassword(ctx context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgChangeAccountPassword]) error {
 	curPass := msg.Payload.CurrentPassword
 	newPass := msg.Payload.NewPassword
 
@@ -410,7 +410,7 @@ func (l LogicImpl) OnChangeAccountPassword(ctx context.Context, client *Client, 
 	return bidi.WriteAck()
 }
 
-func (l LogicImpl) OnSearch(ctx context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgSearch]) error {
+func (l LogicImpl) OnSearch(ctx context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgSearch]) error {
 	if msg.Payload.Query == "" {
 		return bidi.WriteError(pb.ErrType_ERR_TYPE_INVALID_FIELDS, "query cannot be empty")
 	}
@@ -508,7 +508,7 @@ recvLoop:
 	return nil
 }
 
-func (l LogicImpl) OnGetStunServers(ctx context.Context, client *Client, bidi protocol.ProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetStunServers]) error {
+func (l LogicImpl) OnGetStunServers(ctx context.Context, client *Client, bidi protocol.QuicProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetStunServers]) error {
 	var m = &pb.MsgStunServers{
 		Addresses: l.stunAddrs,
 	}

--- a/server/room/proxy.go
+++ b/server/room/proxy.go
@@ -27,8 +27,8 @@ type ClientProxy struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 
-	originBidi protocol.ProtoBidi
-	targetBidi protocol.ProtoBidi
+	originBidi protocol.QuicProtoBidi
+	targetBidi protocol.QuicProtoBidi
 }
 
 const proxyBufSize = 1024
@@ -45,7 +45,7 @@ func NewClientProxy(
 	room *Room,
 	originUsername common.NormalizedUsername,
 	targetUsername common.NormalizedUsername,
-	originBidi protocol.ProtoBidi,
+	originBidi protocol.QuicProtoBidi,
 ) (*ClientProxy, error) {
 	targetClient, isOnline := room.GetClientByUsername(targetUsername)
 	if !isOnline {
@@ -101,7 +101,7 @@ func (p *ClientProxy) Close() error {
 	return fmt.Errorf("closing proxy bidi streams failed: %w", errors.Join(errs...))
 }
 
-func (p *ClientProxy) proxyThread(from protocol.ProtoBidi, to protocol.ProtoBidi) error {
+func (p *ClientProxy) proxyThread(from protocol.QuicProtoBidi, to protocol.QuicProtoBidi) error {
 	_, err := io.Copy(to.Stream, from.Stream)
 	return err
 }

--- a/server/room/room.go
+++ b/server/room/room.go
@@ -202,7 +202,7 @@ func (r *Room) Broadcast(typ pb.MsgType, msg proto.Message) {
 // If there is an existing client with the username, returns ErrUsernameAlreadyConnected.
 // This method will not close the connection if it returns an error; it is the caller's responsibility to close it if an error is returned.
 func (r *Room) Onboard(
-	authBidi protocol.ProtoBidi,
+	authBidi protocol.QuicProtoBidi,
 	conn protocol.ProtoConn,
 	version *pb.ProtoVersion,
 	username common.NormalizedUsername,


### PR DESCRIPTION
Refactor ProtoBidi to be all io Reader/Writer work instead of specifically quic.Stream. Add an ability to loopback messages. This makes no actual connections and fixes #35. Also remove some duplicate code wrt ReadExpect.