### PR TITLE
Fix C2C latency

### DIFF
--- a/client/downloadmanager.go
+++ b/client/downloadmanager.go
@@ -369,7 +369,7 @@ func (dm *DownloadManager) updateDrainer() {
 
 						// Send updates to peers.
 						for username, upds := range byPeer {
-							peer := conn.GetVirtualC2cConn(username, false)
+							peer := conn.GetVirtualC2cConn(username, room.C2cConnModeQuickFallback)
 
 							go func() {
 								bidi, err := peer.OpenBidiWithMsg(pb.MsgType_MSG_TYPE_DOWNLOAD_STATUS_UPDATE, upds[0].ToProto())
@@ -680,7 +680,7 @@ func (dm *DownloadManager) startDownload(handle *DownloadHandle) error {
 
 	// Use TryDo because we want to fail fast if there is not an open connection.
 	finalErr := handle.server.TryDo(func(conn *room.Conn) error {
-		peer := conn.GetVirtualC2cConn(handle.peer, false)
+		peer := conn.GetVirtualC2cConn(handle.peer, room.C2cConnModeDefault)
 
 		initialDownloaded := handle.fileDownloadedBytes.Load()
 

--- a/client/fileserver.go
+++ b/client/fileserver.go
@@ -154,7 +154,7 @@ func (s *FileServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = server.Do(r.Context(), func(ctx context.Context, c *room.Conn) error {
-		peer := c.GetVirtualC2cConn(username, false)
+		peer := c.GetVirtualC2cConn(username, room.C2cConnModeDefault)
 
 		// Get metadata before getting file.
 		// This is necessary for range requests.

--- a/client/fsys/peerfs/peerfs.go
+++ b/client/fsys/peerfs/peerfs.go
@@ -50,7 +50,7 @@ type PeerFs struct {
 func NewPeerFs(roomConn *room.Conn, username common.NormalizedUsername, opts ...Option) *PeerFs {
 	pfs := &PeerFs{
 		roomConn: roomConn,
-		peer:     roomConn.GetVirtualC2cConn(username, false),
+		peer:     roomConn.GetVirtualC2cConn(username, room.C2cConnModeDefault),
 		username: username,
 	}
 

--- a/client/room/conn.go
+++ b/client/room/conn.go
@@ -43,6 +43,35 @@ type Credentials struct {
 // Arbitrary size to prevent lockups on the incoming bidi channel.
 const incomingBidiChanSize = 64
 
+// PingStats are direct connection ping statistics.
+type PingStats struct {
+	LastPing time.Time
+	Rtt      time.Duration
+}
+
+// DirectConnEntry is a direct connection to a peer.
+// It stores the connection and the last ping round trip time.
+// It also stores the last ping timestamp. When sorting connections, we can downrank connections
+// whose last ping time is longer from the current time than the ping interval we use. That can
+// help avoid dying or congested connections.
+type DirectConnEntry struct {
+	Conn protocol.ProtoConn
+
+	statsMu sync.Mutex
+	stats   PingStats
+}
+
+func (e *DirectConnEntry) GetPingStats() PingStats {
+	e.statsMu.Lock()
+	defer e.statsMu.Unlock()
+	return e.stats
+}
+func (e *DirectConnEntry) SetPingStats(stats PingStats) {
+	e.statsMu.Lock()
+	defer e.statsMu.Unlock()
+	e.stats = stats
+}
+
 // Conn represents a room connection.
 // The room connection contains a connection to a central server, as well as potentially direct connections with peers in the room.
 // A Conn is always in an authenticated and usable state until it is closed, either by calling RoomConn.Close, or the connection being interrupted.
@@ -85,8 +114,9 @@ type Conn struct {
 	// Direct connections to room clients.
 	// The connections could have been outgoing or incoming,
 	// but they are treated the same once established.
-	// The key is the client username, the value is a set of connections.
-	directConns map[common.NormalizedUsername]map[protocol.ProtoConn]struct{}
+	// The key is the client username, the value is a list of connections.
+	// The connections can be sorted as needed when accessing.
+	directConns map[common.NormalizedUsername][]*DirectConnEntry
 
 	// A cache of direct connect methods for room clients.
 	// If no methods are available for a client, the slice will be empty.
@@ -229,7 +259,7 @@ func NewConn(
 
 		directMgr:                     directMgr,
 		directPart:                    directPart,
-		directConns:                   make(map[common.NormalizedUsername]map[protocol.ProtoConn]struct{}),
+		directConns:                   make(map[common.NormalizedUsername][]*DirectConnEntry),
 		directPeerMethods:             make(map[common.NormalizedUsername][]*pb.ConnMethod),
 		directSelfMethods:             make(map[string]*pb.ConnMethod),
 		directConnectOutgoingFailures: make(map[common.NormalizedUsername]struct{}),
@@ -325,8 +355,8 @@ func (c *Conn) Close() error {
 
 	directConns := make([]protocol.ProtoConn, 0, len(c.directConns)*3)
 	for _, set := range c.directConns {
-		for conn := range set {
-			directConns = append(directConns, conn)
+		for _, entry := range set {
+			directConns = append(directConns, entry.Conn)
 		}
 	}
 
@@ -427,7 +457,8 @@ func (c *Conn) openC2cBidiWithMsg(
 
 		// Are we already connected?
 		if len(existing) > 0 {
-			directConn = existing[0]
+			// TODO Sort before doing this
+			directConn = existing[0].Conn
 			goto openBidi
 		}
 
@@ -596,7 +627,8 @@ func (c *Conn) openC2cBidiWithMsg(
 		)
 
 		// The peer successfully connected to us!
-		directConn = existing[0]
+		// TODO Sort here (maybe move it to a function)
+		directConn = existing[0].Conn
 		goto openBidi
 	}
 

--- a/client/room/conn.go
+++ b/client/room/conn.go
@@ -111,6 +111,9 @@ type Conn struct {
 	// The direct connect server partition.
 	directPart *direct.Partition
 
+	// A set of usernames that we are currently attempting a direct connection on.
+	pendingDirectConns map[common.NormalizedUsername]struct{}
+
 	// Direct connections to room clients.
 	// The connections could have been outgoing or incoming,
 	// but they are treated the same once established.
@@ -259,6 +262,7 @@ func NewConn(
 
 		directMgr:                     directMgr,
 		directPart:                    directPart,
+		pendingDirectConns:            make(map[common.NormalizedUsername]struct{}),
 		directConns:                   make(map[common.NormalizedUsername][]*DirectConnEntry),
 		directPeerMethods:             make(map[common.NormalizedUsername][]*pb.ConnMethod),
 		directSelfMethods:             make(map[string]*pb.ConnMethod),
@@ -429,6 +433,190 @@ func (c *Conn) openProxiedC2cBidi(username common.NormalizedUsername) (protocol.
 	return bidi, nil
 }
 
+func (c *Conn) tryDirectConnect(
+	hasFailedOutgoing bool,
+	hasFailedConnectToMe bool,
+	username common.NormalizedUsername,
+	selfMethods []*pb.ConnMethod,
+) (protocol.ProtoConn, error) {
+	c.mu.Lock()
+	c.pendingDirectConns[username] = struct{}{}
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		delete(c.pendingDirectConns, username)
+		c.mu.Unlock()
+	}()
+
+	timeoutCtx, ctxCancel := context.WithTimeout(c.Context, c.directOutgoingTimeout)
+	defer ctxCancel()
+
+	var directConn protocol.ProtoConn
+	var connErr error
+
+	// Have we already tried and failed to connect to this peer?
+	if hasFailedOutgoing {
+		goto tryConnectToMe
+	}
+
+	// Try to connect directly.
+	directConn, _, connErr = c.tryConnectToPeer(timeoutCtx, username)
+	if connErr != nil {
+		// Was the client not online?
+		if protoErr, ok := errors.AsType[protocol.ProtoMsgError](connErr); ok {
+			if protoErr.Msg.Type == pb.ErrType_ERR_TYPE_CLIENT_NOT_ONLINE {
+				// The client was offline.
+				// Just return the error as-is.
+				// Do not cache failure.
+				return nil, connErr
+			}
+		}
+
+		// Record this failure.
+		c.mu.Lock()
+		c.directConnectOutgoingFailures[username] = struct{}{}
+		c.mu.Unlock()
+
+		if errors.Is(connErr, errNoPeerMethods) {
+			// No peer methods.
+			// Try to have the peer connect to us.
+			goto tryConnectToMe
+		}
+
+		c.logger.Warn("all methods failed to connect to peer",
+			"service", "room.Conn",
+			"room", c.RoomName.String(),
+			"peer", username.String(),
+			"err", connErr,
+		)
+
+		// Oh well.
+		// Let's try to have the peer connect to us.
+		goto tryConnectToMe
+	}
+
+	// Successfully made direct connection!
+	return directConn, nil
+
+tryConnectToMe:
+
+	// The heuristic follows these steps in order:
+	//  - Do we have a cached CONNECT_TO_ME failure? If so, proxy.
+	//  - Do we have any verified IP methods? If so, CONNECT_TO_ME.
+	//  - Do we have any Yggdrasil methods? If so, CONNECT_TO_ME.
+	//  - If none of the above, proxy.
+
+	if hasFailedConnectToMe {
+		// The client tried and failed to connect to us before.
+		// Fall back to proxy.
+		return nil, nil
+	}
+
+	for _, method := range selfMethods {
+		if method.Type == pb.ConnMethodType_CONN_METHOD_TYPE_IP && method.IsServerVerified {
+			goto connectToMe
+		}
+		if method.Type == pb.ConnMethodType_CONN_METHOD_TYPE_YGGDRASIL {
+			goto connectToMe
+		}
+		if method.Type == pb.ConnMethodType_CONN_METHOD_TYPE_NAT_HOLEPUNCH {
+			goto connectToMe
+		}
+	}
+
+	c.logger.Warn("no suitable self method found, will not ask peer to connect to us",
+		"service", "room.Conn",
+		"room", c.RoomName.String(),
+		"peer", username.String(),
+	)
+
+	// Record this failure.
+	c.mu.Lock()
+	c.directConnectToMeFailures[username] = struct{}{}
+	c.mu.Unlock()
+
+	// No suitable self method found, otherwise would have jumped to connectToMe.
+	// Fall back to proxy.
+	return nil, nil
+
+connectToMe:
+	c.logger.Info("asking client to connect to us",
+		"service", "room.Conn",
+		"room", c.RoomName.String(),
+		"peer", username.String(),
+	)
+
+	// Ask the peer to connect to us.
+	bidi, err := c.openProxiedC2cBidi(username)
+	if err != nil {
+		return nil, err
+	}
+	err = bidi.Write(pb.MsgType_MSG_TYPE_CONNECT_TO_ME, &pb.MsgConnectToMe{})
+	if err != nil {
+		if c.isErrProxyPeerUnreachable(err) {
+			return nil, protocol.ErrPeerUnreachable
+		}
+		_ = bidi.Close()
+		return nil, err
+	}
+	ctmRes, err := protocol.ReadExpect[*pb.MsgDirectConnResult](bidi, pb.MsgType_MSG_TYPE_DIRECT_CONN_RESULT)
+	if err != nil {
+		if c.isErrProxyPeerUnreachable(err) {
+			return nil, protocol.ErrPeerUnreachable
+		}
+		_ = bidi.Close()
+		return nil, err
+	}
+	if ctmRes.Payload.Result != pb.ConnResult_CONN_RESULT_OK {
+		_ = bidi.Close()
+
+		c.logger.Warn("peer said they could not connect to us",
+			"service", "room.Conn",
+			"room", c.RoomName.String(),
+			"peer", username.String(),
+			"result", ctmRes.Payload.Result.String(),
+		)
+
+		// The peer could not connect.
+		// Record this to save time later.
+		c.mu.Lock()
+		c.directConnectToMeFailures[username] = struct{}{}
+		c.mu.Unlock()
+		c.logger.Warn("we asked a peer to connect to us, but it could not",
+			"service", "room.Conn",
+			"room", c.RoomName.String(),
+			"peer", username.String(),
+			"result", ctmRes.Payload.Result.String(),
+		)
+
+		// Fall back to proxy.
+		return nil, nil
+	}
+
+	// The peer said they were able to connect to us.
+	// Check if the connection is active.
+	existing := c.GetDirectConns(username)
+	if len(existing) == 0 {
+		c.logger.Warn("a peer said they connected to us, but no connection was found",
+			"service", "room.Conn",
+			"room", c.RoomName.String(),
+			"peer", username.String(),
+		)
+
+		// Fall back to proxy.
+		return nil, nil
+	}
+
+	c.logger.Info("peer successfully connected to us",
+		"service", "room.Conn",
+		"room", c.RoomName.String(),
+		"peer", username.String(),
+	)
+
+	// The peer successfully connected to us!
+	return existing[0].Conn, nil
+}
+
 // openC2cBidiWithMsg opens a bidi to a destination peer.
 // If the peer is definitely unreachable, returns protocol.ErrPeerUnreachable.
 // It may not return an error if the peer is unreachable immediately, but read methods
@@ -440,10 +628,10 @@ func (c *Conn) openC2cBidiWithMsg(
 	username common.NormalizedUsername,
 	typ pb.MsgType,
 	msg proto.Message,
-	forceProxy bool,
+	connMode C2cConnMode,
 ) (protocol.ProtoBidi, error) {
 	var directConn protocol.ProtoConn
-	if !forceProxy && !c.directMgr.IsDisabled() {
+	if connMode != C2cConnModeAlwaysProxy && !c.directMgr.IsDisabled() {
 		// Collect information that will be useful for helping us connect.
 		existing := c.GetDirectConns(username)
 		c.mu.RLock()
@@ -453,182 +641,53 @@ func (c *Conn) openC2cBidiWithMsg(
 		}
 		_, hasFailedConnectToMe := c.directConnectToMeFailures[username]
 		_, hasFailedOutgoing := c.directConnectOutgoingFailures[username]
+		_, hasPendingConn := c.pendingDirectConns[username]
 		c.mu.RUnlock()
 
 		// Are we already connected?
 		if len(existing) > 0 {
-			// TODO Sort before doing this
 			directConn = existing[0].Conn
 			goto openBidi
 		}
 
-		timeoutCtx, ctxCancel := context.WithTimeout(c.Context, c.directOutgoingTimeout)
-		defer ctxCancel()
-
-		var connErr error
-
-		// Have we already tried and failed to connect to this peer?
-		if hasFailedOutgoing {
-			goto tryConnectToMe
-		}
-
-		// Try to connect directly.
-		directConn, _, connErr = c.tryConnectToPeer(timeoutCtx, username)
-		if connErr != nil {
-			// Was the client not online?
-			if protoErr, ok := errors.AsType[protocol.ProtoMsgError](connErr); ok {
-				if protoErr.Msg.Type == pb.ErrType_ERR_TYPE_CLIENT_NOT_ONLINE {
-					// The client was offline.
-					// Just return the error as-is.
-					// Do not cache failure.
-					return protocol.ProtoBidi{}, connErr
-				}
+		// If we are already pending a connection, just fallback on proxy immediately
+		if connMode == C2cConnModeQuickFallback {
+			if !hasPendingConn {
+				// Connection will get adopted automatically if successful.
+				go func() {
+					_, err := c.tryDirectConnect(
+						hasFailedOutgoing,
+						hasFailedConnectToMe,
+						username,
+						selfMethods,
+					)
+					if err != nil {
+						c.logger.Error("background direct connection failed",
+							"service", "room.Conn",
+							"room", c.RoomName.String(),
+							"peer", username.String(),
+							"err", err,
+						)
+					}
+				}()
 			}
 
-			// Record this failure.
-			c.mu.Lock()
-			c.directConnectOutgoingFailures[username] = struct{}{}
-			c.mu.Unlock()
-
-			if errors.Is(connErr, errNoPeerMethods) {
-				// No peer methods.
-				// Try to have the peer connect to us.
-				goto tryConnectToMe
-			}
-
-			c.logger.Warn("all methods failed to connect to peer",
-				"service", "room.Conn",
-				"room", c.RoomName.String(),
-				"peer", username.String(),
-				"err", connErr,
-			)
-
-			// Oh well.
-			// Let's try to have the peer connect to us.
-			goto tryConnectToMe
-		}
-
-		// Successfully made direct connection!
-		goto openBidi
-
-	tryConnectToMe:
-
-		// The heuristic follows these steps in order:
-		//  - Do we have a cached CONNECT_TO_ME failure? If so, proxy.
-		//  - Do we have any verified IP methods? If so, CONNECT_TO_ME.
-		//  - Do we have any Yggdrasil methods? If so, CONNECT_TO_ME.
-		//  - If none of the above, proxy.
-
-		if hasFailedConnectToMe {
-			// The client tried and failed to connect to us before.
-			// Fall back to proxy.
+			// Connection kicked off in the background, but fall back to proxied for this request.
 			goto openBidi
 		}
 
-		for _, method := range selfMethods {
-			if method.Type == pb.ConnMethodType_CONN_METHOD_TYPE_IP && method.IsServerVerified {
-				goto connectToMe
-			}
-			if method.Type == pb.ConnMethodType_CONN_METHOD_TYPE_YGGDRASIL {
-				goto connectToMe
-			}
-			if method.Type == pb.ConnMethodType_CONN_METHOD_TYPE_NAT_HOLEPUNCH {
-				goto connectToMe
-			}
-		}
-
-		c.logger.Warn("no suitable self method found, will not ask peer to connect to us",
-			"service", "room.Conn",
-			"room", c.RoomName.String(),
-			"peer", username.String(),
+		// Try to connect blocking.
+		var err error
+		directConn, err = c.tryDirectConnect(
+			hasFailedOutgoing,
+			hasFailedConnectToMe,
+			username,
+			selfMethods,
 		)
-
-		// Record this failure.
-		c.mu.Lock()
-		c.directConnectToMeFailures[username] = struct{}{}
-		c.mu.Unlock()
-
-		// No suitable self method found, otherwise would have jumped to connectToMe.
-		// Fall back to proxy.
-		goto openBidi
-
-	connectToMe:
-		c.logger.Info("asking client to connect to us",
-			"service", "room.Conn",
-			"room", c.RoomName.String(),
-			"peer", username.String(),
-		)
-
-		// Ask the peer to connect to us.
-		bidi, err := c.openProxiedC2cBidi(username)
 		if err != nil {
 			return protocol.ProtoBidi{}, err
 		}
-		err = bidi.Write(pb.MsgType_MSG_TYPE_CONNECT_TO_ME, &pb.MsgConnectToMe{})
-		if err != nil {
-			if c.isErrProxyPeerUnreachable(err) {
-				return protocol.ProtoBidi{}, protocol.ErrPeerUnreachable
-			}
-			_ = bidi.Close()
-			return protocol.ProtoBidi{}, err
-		}
-		ctmRes, err := protocol.ReadExpect[*pb.MsgDirectConnResult](bidi, pb.MsgType_MSG_TYPE_DIRECT_CONN_RESULT)
-		if err != nil {
-			if c.isErrProxyPeerUnreachable(err) {
-				return protocol.ProtoBidi{}, protocol.ErrPeerUnreachable
-			}
-			_ = bidi.Close()
-			return protocol.ProtoBidi{}, err
-		}
-		if ctmRes.Payload.Result != pb.ConnResult_CONN_RESULT_OK {
-			_ = bidi.Close()
 
-			c.logger.Warn("peer said they could not connect to us",
-				"service", "room.Conn",
-				"room", c.RoomName.String(),
-				"peer", username.String(),
-				"result", ctmRes.Payload.Result.String(),
-			)
-
-			// The peer could not connect.
-			// Record this to save time later.
-			c.mu.Lock()
-			c.directConnectToMeFailures[username] = struct{}{}
-			c.mu.Unlock()
-			c.logger.Warn("we asked a peer to connect to us, but it could not",
-				"service", "room.Conn",
-				"room", c.RoomName.String(),
-				"peer", username.String(),
-				"result", ctmRes.Payload.Result.String(),
-			)
-
-			// Fall back to proxy.
-			goto openBidi
-		}
-
-		// The peer said they were able to connect to us.
-		// Check if the connection is active.
-		existing = c.GetDirectConns(username)
-		if len(existing) == 0 {
-			c.logger.Warn("a peer said they connected to us, but no connection was found",
-				"service", "room.Conn",
-				"room", c.RoomName.String(),
-				"peer", username.String(),
-			)
-
-			// Fall back to proxy.
-			goto openBidi
-		}
-
-		c.logger.Info("peer successfully connected to us",
-			"service", "room.Conn",
-			"room", c.RoomName.String(),
-			"peer", username.String(),
-		)
-
-		// The peer successfully connected to us!
-		// TODO Sort here (maybe move it to a function)
-		directConn = existing[0].Conn
 		goto openBidi
 	}
 
@@ -663,13 +722,12 @@ openBidi:
 // Methods on the returned VirtualC2cConn may return protocol.ErrPeerUnreachable if the
 // desired peer is unavailable.
 //
-// If forceProxy is true, it will always proxy to the peer instead of using a direct connection.
-// It may still fall back to proxying if no direct connection method is available.
-func (c *Conn) GetVirtualC2cConn(peer common.NormalizedUsername, forceProxy bool) VirtualC2cConn {
+// Bidis opened by the VirtualC2cConn will use the specified mode.
+func (c *Conn) GetVirtualC2cConn(peer common.NormalizedUsername, mode C2cConnMode) VirtualC2cConn {
 	return VirtualC2cConn{
 		ServerConn: c,
 		Username:   peer,
-		ForceProxy: forceProxy,
+		ConnMode:   mode,
 	}
 }
 

--- a/client/room/direct.go
+++ b/client/room/direct.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"math"
 	"net"
 	"net/netip"
 	"slices"
@@ -36,11 +37,32 @@ func (c *Conn) directCacheGc() {
 	}
 }
 
-// GetDirectConns returns all direct connections to the specified peer.
+// SortDirectConnEntriesByRtt sorts direct connections based on ping RTT, lowest first.
+// Entries whose last ping time was longer ago than the ping interval will be ranked at the end of the list
+// because they're probably dying.
+func SortDirectConnEntriesByRtt(entries []*DirectConnEntry) {
+	slices.SortFunc(entries, func(a, b *DirectConnEntry) int {
+		// If last ping was longer than the ping interval, this connection is dying or congested.
+		now := time.Now()
+		aStats := a.GetPingStats()
+		bStats := b.GetPingStats()
+
+		if now.Sub(aStats.LastPing) > ServerPingInterval {
+			return math.MinInt
+		}
+		if now.Sub(bStats.LastPing) > ServerPingInterval {
+			return math.MinInt
+		}
+
+		return int(aStats.Rtt) - int(bStats.Rtt)
+	})
+}
+
+// GetDirectConns returns all direct connections to the specified peer, sorted by fastest round trip time.
 // It does not differentiate between connections that we initiated and ones that the peer initiated.
 // Note that this method creates a new slice each time it is called, and it RLocks the Conn mutex.
 // If the Conn is closed, returns empty.
-func (c *Conn) GetDirectConns(username common.NormalizedUsername) []protocol.ProtoConn {
+func (c *Conn) GetDirectConns(username common.NormalizedUsername) []*DirectConnEntry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.isClosed {
@@ -52,10 +74,13 @@ func (c *Conn) GetDirectConns(username common.NormalizedUsername) []protocol.Pro
 		return nil
 	}
 
-	res := make([]protocol.ProtoConn, 0, len(set))
-	for conn := range set {
+	res := make([]*DirectConnEntry, 0, len(set))
+	for _, conn := range set {
 		res = append(res, conn)
 	}
+
+	// Sort by lowest ping.
+	SortDirectConnEntriesByRtt(res)
 
 	return res
 }
@@ -68,18 +93,26 @@ func (c *Conn) GetDirectConns(username common.NormalizedUsername) []protocol.Pro
 func (c *Conn) AdoptDirectConn(conn protocol.ProtoConn, username common.NormalizedUsername) (alreadyOwned bool) {
 	c.mu.Lock()
 
-	set, has := c.directConns[username]
+	conns, has := c.directConns[username]
 	if !has {
-		set = make(map[protocol.ProtoConn]struct{})
-		c.directConns[username] = set
+		var conns []*DirectConnEntry
+		c.directConns[username] = conns
 	}
 
-	_, has = set[conn]
-	if has {
-		return true
+	for _, entry := range conns {
+		if entry.Conn == conn {
+			return
+		}
 	}
 
-	set[conn] = struct{}{}
+	connEntry := &DirectConnEntry{
+		Conn: conn,
+		stats: PingStats{
+			LastPing: time.Now(),
+			Rtt:      0,
+		},
+	}
+	conns = append(conns, connEntry)
 
 	c.mu.Unlock()
 
@@ -95,6 +128,8 @@ func (c *Conn) AdoptDirectConn(conn protocol.ProtoConn, username common.Normaliz
 				_ = conn.CloseWithReason("goodbye")
 				return
 			case <-ticker.C:
+				pingStart := time.Now()
+
 				_, pingErr := protocol.SendAndReceiveExpect[*pb.MsgPong](
 					conn,
 					pb.MsgType_MSG_TYPE_PING,
@@ -115,6 +150,14 @@ func (c *Conn) AdoptDirectConn(conn protocol.ProtoConn, username common.Normaliz
 					)
 					return
 				}
+
+				rtt := time.Now().Sub(pingStart)
+
+				// Update ping stats on entry.
+				connEntry.SetPingStats(PingStats{
+					LastPing: pingStart,
+					Rtt:      rtt,
+				})
 			}
 		}
 	}()
@@ -134,11 +177,20 @@ func (c *Conn) AdoptDirectConn(conn protocol.ProtoConn, username common.Normaliz
 
 		disown := func() {
 			c.mu.Lock()
-			set, has = c.directConns[username]
-			if has {
-				delete(set, conn)
+			defer c.mu.Unlock()
+
+			conns, has = c.directConns[username]
+			if !has {
+				return
 			}
-			c.mu.Unlock()
+
+			for i, entry := range conns {
+				if entry.Conn == conn {
+					// Remove from slice and shift elements back.
+					conns = append(conns[:i], conns[i+1:]...)
+					break
+				}
+			}
 		}
 		defer func() {
 			disown()

--- a/client/room/direct.go
+++ b/client/room/direct.go
@@ -705,7 +705,7 @@ func (c *Conn) directConnect(ctx context.Context, peer common.NormalizedUsername
 		fmtAddr := fmt.Sprintf("%s:%d", ownAddr.Addr().String(), ownAddr.Port())
 
 		// Send punch offer to peer.
-		peerConn := c.GetVirtualC2cConn(peer, true)
+		peerConn := c.GetVirtualC2cConn(peer, C2cConnModeAlwaysProxy)
 		punchAccept, err := protocol.SendAndReceiveExpect[*pb.MsgPunchAccept](
 			peerConn,
 			pb.MsgType_MSG_TYPE_PUNCH_OFFER,

--- a/client/room/direct_test.go
+++ b/client/room/direct_test.go
@@ -1,0 +1,54 @@
+package room
+
+import (
+	"testing"
+	"time"
+
+	"friendnet.org/protocol"
+)
+
+type dummyConn struct {
+	protocol.ProtoConn
+}
+
+func TestSortByRtt(t *testing.T) {
+	conn1 := &dummyConn{}
+	conn2 := &dummyConn{}
+	conn3 := &dummyConn{}
+
+	entries := []*DirectConnEntry{
+		&DirectConnEntry{
+			Conn: conn1,
+			stats: PingStats{
+				LastPing: time.Now().Add(-(ServerPingInterval + time.Second)),
+				Rtt:      0,
+			},
+		},
+		&DirectConnEntry{
+			Conn: conn2,
+			stats: PingStats{
+				LastPing: time.Now(),
+				Rtt:      0,
+			},
+		},
+		&DirectConnEntry{
+			Conn: conn3,
+			stats: PingStats{
+				LastPing: time.Now(),
+				Rtt:      100 * time.Microsecond,
+			},
+		},
+	}
+
+	SortDirectConnEntriesByRtt(entries)
+
+	if entries[0].Conn != conn2 {
+		t.Fatalf("conn2 should have been first")
+	}
+	if entries[1].Conn != conn3 {
+		t.Fatalf("conn3 should have been second")
+	}
+	if entries[2].Conn != conn1 {
+		t.Fatalf("conn1 should have been third")
+	}
+}

--- a/client/room/virtualc2c.go
+++ b/client/room/virtualc2c.go
@@ -15,6 +15,22 @@ import (
 // Channel that is never closed or written, to satisfy ProtoConn.OnDisconnect.
 var virtualC2cConnOnDiscChan = make(chan struct{})
 
+// VirtualC2cConnMode is a type of virtual C2C connection mode.
+type C2cConnMode int
+
+const (
+	// C2cConnModeDefault is the default mode for virtual C2C connections.
+	// It tries to direct connect if not already connected, and if it times out, it finally falls back to proxied.
+	C2cConnModeDefault C2cConnMode = iota
+
+	// C2cConnModeAlwaysProxy will always use the proxy in place of connecting directly.
+	C2cConnModeAlwaysProxy
+
+	// C2cConnModeQuickFallback will instantly fall back on the proxy if no existing connection exists.
+	// If none exists, it will try to kick off a direct connection in the background.
+	C2cConnModeQuickFallback
+)
+
 // VirtualC2cConn is a virtual connection to another client.
 // It is stateless and does not manage any direct or proxied connections.
 // It exists to implement protocol.ProtoConn.
@@ -25,9 +41,8 @@ type VirtualC2cConn struct {
 	// The client's username.
 	Username common.NormalizedUsername
 
-	// Whether to force proxying instead of using a direct connection.
-	// It may still fall back to proxying if no direct connection method is available.
-	ForceProxy bool
+	// The connection mode to use.
+	ConnMode C2cConnMode
 }
 
 // OnDisconnect returns a channel that never closes for VirtualC2cConn.
@@ -72,7 +87,7 @@ func (c VirtualC2cConn) OpenBidiWithMsg(typ pb.MsgType, msg proto.Message) (bidi
 	}
 
 	// Do a normal C2C message.
-	return c.ServerConn.openC2cBidiWithMsg(c.Username, typ, msg, c.ForceProxy)
+	return c.ServerConn.openC2cBidiWithMsg(c.Username, typ, msg, c.ConnMode)
 }
 
 func (c VirtualC2cConn) WaitForBidi(ctx context.Context) (protocol.ProtoBidi, error) {

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -423,7 +423,7 @@ func (s *RpcServer) GetDirFiles(ctx context.Context, request *v1.GetDirFilesRequ
 	}
 
 	return srv.Do(ctx, func(ctx context.Context, c *room.Conn) error {
-		peer := c.GetVirtualC2cConn(username, false)
+		peer := c.GetVirtualC2cConn(username, room.C2cConnModeQuickFallback)
 		stream, err := peer.GetDirFiles(path)
 		if err != nil {
 			return err
@@ -486,7 +486,7 @@ func (s *RpcServer) GetFileMeta(ctx context.Context, request *v1.GetFileMetaRequ
 	}
 
 	return DoValue(srv.ConnNanny, ctx, func(ctx context.Context, c *room.Conn) (*v1.GetFileMetaResponse, error) {
-		peer := c.GetVirtualC2cConn(username, false)
+		peer := c.GetVirtualC2cConn(username, room.C2cConnModeQuickFallback)
 		meta, err := peer.GetFileMeta(path)
 		if err != nil {
 			if protoMsgErr, ok := errors.AsType[protocol.ProtoMsgError](err); ok {
@@ -767,7 +767,7 @@ func (s *RpcServer) StreamSearch(ctx context.Context, request *v1.StreamSearchRe
 		}
 	}
 	streamPeerSearchResults := func(c *room.Conn, server *Server, username common.NormalizedUsername) error {
-		peer := c.GetVirtualC2cConn(username, false)
+		peer := c.GetVirtualC2cConn(username, room.C2cConnModeQuickFallback)
 
 		stream, err := peer.Search(request.Query)
 		if err != nil {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -584,11 +584,21 @@ func (bidi *ProtoStreamWriter) WriteUnimplementedError(msgType pb.MsgType) error
 // ProtoBidi is a bidirection protocol message stream.
 // It can also expose its raw byte reader and writer.
 type ProtoBidi struct {
-	close  func() error
-	reader io.Reader
-	writer io.Writer
+	close      func() error
+	cancelRead func(code uint64)
+	reader     io.Reader
+	writer     io.Writer
 	*ProtoStreamReader
 	*ProtoStreamWriter
+}
+
+// CancelRead calls a function to cancel a stream with an error code.
+// May be no-op, depending on the implementation.
+// This is a hacky fix for VirtualC2cConn proxied bidis. We'll figure out a generic side-channel later.
+func (bidi ProtoBidi) CancelRead(code uint64) {
+	if bidi.cancelRead != nil {
+		bidi.cancelRead(code)
+	}
 }
 
 // RawReader returns the bidi's raw byte reader.
@@ -610,9 +620,12 @@ func (bidi ProtoBidi) Close() error {
 func NewQuicProtoBidi(stream *quic.Stream) ProtoBidi {
 	return ProtoBidi{
 		close: func() error {
+			_ = stream.Close()
 			stream.CancelRead(0)
-			stream.CancelWrite(0)
-			return stream.Close()
+			return nil
+		},
+		cancelRead: func(code uint64) {
+			stream.CancelRead(quic.StreamErrorCode(code))
 		},
 		reader:            stream,
 		writer:            stream,

--- a/server/lobby/lobby.go
+++ b/server/lobby/lobby.go
@@ -147,7 +147,7 @@ func (l *Lobby) negotiateClientVersion(
 	}()
 
 	finalErr = func() error {
-		msg, err := protocol.ReadExpect[*pb.MsgVersion](bidi.ProtoStreamReader, pb.MsgType_MSG_TYPE_VERSION)
+		msg, err := protocol.ReadExpect[*pb.MsgVersion](bidi, pb.MsgType_MSG_TYPE_VERSION)
 		if err != nil {
 			return err
 		}
@@ -214,7 +214,7 @@ var ipv4Zero = netip.AddrFrom4([4]byte{0, 0, 0, 0})
 func (l *Lobby) authenticateClient(
 	ctx context.Context,
 	conn protocol.ProtoConn,
-) (authBidi protocol.QuicProtoBidi, room common.NormalizedRoomName, username common.NormalizedUsername, finalErr error) {
+) (authBidi protocol.ProtoBidi, room common.NormalizedRoomName, username common.NormalizedUsername, finalErr error) {
 	isSuccess := false
 	var bidiErr error
 	authBidi, bidiErr = conn.WaitForBidi(ctx)
@@ -228,7 +228,7 @@ func (l *Lobby) authenticateClient(
 	}()
 
 	finalErr = func() error {
-		msg, err := protocol.ReadExpect[*pb.MsgAuthenticate](authBidi.ProtoStreamReader, pb.MsgType_MSG_TYPE_AUTHENTICATE)
+		msg, err := protocol.ReadExpect[*pb.MsgAuthenticate](authBidi, pb.MsgType_MSG_TYPE_AUTHENTICATE)
 		if err != nil {
 			return err
 		}

--- a/server/room/client.go
+++ b/server/room/client.go
@@ -63,7 +63,7 @@ func NewClient(
 // msgHandler handles a message from a client.
 // It must not close the bidi passed to it.
 // After returning, the bidi will be closed.
-func (c *Client) msgHandler(bidi protocol.QuicProtoBidi, firstMsg *protocol.UntypedProtoMsg) error {
+func (c *Client) msgHandler(bidi protocol.ProtoBidi, firstMsg *protocol.UntypedProtoMsg) error {
 	ctx := context.Background()
 
 	switch firstMsg.Type {
@@ -114,7 +114,7 @@ func (c *Client) msgHandler(bidi protocol.QuicProtoBidi, firstMsg *protocol.Unty
 // bidiHandler handles a new C2S bidi.
 // It must not close the bidi passed to it.
 // After returning, the bidi will be closed.
-func (c *Client) bidiHandler(bidi protocol.QuicProtoBidi) {
+func (c *Client) bidiHandler(bidi protocol.ProtoBidi) {
 	// Read first message.
 	firstMsg, firstErr := bidi.Read()
 	if firstErr != nil {

--- a/server/room/logic.go
+++ b/server/room/logic.go
@@ -27,7 +27,7 @@ type Logic interface {
 	OnPing(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgPing],
 	) error
 
@@ -36,7 +36,7 @@ type Logic interface {
 	OnOpenOutboundProxy(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgOpenOutboundProxy],
 	) error
 
@@ -45,7 +45,7 @@ type Logic interface {
 	OnGetOnlineUsers(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetOnlineUsers],
 	) error
 
@@ -54,7 +54,7 @@ type Logic interface {
 	OnAdvertiseConnMethod(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgAdvertiseConnMethod],
 	) error
 
@@ -63,7 +63,7 @@ type Logic interface {
 	OnRemoveConnMethod(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgRemoveConnMethod],
 	) error
 
@@ -72,7 +72,7 @@ type Logic interface {
 	OnGetPublicIp(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetPublicIp],
 	) error
 
@@ -81,7 +81,7 @@ type Logic interface {
 	OnGetClientConnMethods(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetClientConnMethods],
 	) error
 
@@ -90,7 +90,7 @@ type Logic interface {
 	OnGetDirectConnHandshakeToken(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetDirectConnHandshakeToken],
 	) error
 
@@ -99,7 +99,7 @@ type Logic interface {
 	OnRedeemConnHandshakeToken(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgRedeemConnHandshakeToken],
 	) error
 
@@ -108,7 +108,7 @@ type Logic interface {
 	OnChangeAccountPassword(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgChangeAccountPassword],
 	) error
 
@@ -117,14 +117,14 @@ type Logic interface {
 	OnSearch(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgSearch],
 	) error
 
 	OnGetStunServers(
 		ctx context.Context,
 		client *Client,
-		bidi protocol.QuicProtoBidi,
+		bidi protocol.ProtoBidi,
 		msg *protocol.TypedProtoMsg[*pb.MsgGetStunServers],
 	) error
 }
@@ -155,17 +155,17 @@ func NewLogicImpl(
 	}
 }
 
-func (l LogicImpl) OnPing(_ context.Context, _ *Client, bidi protocol.QuicProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgPing]) error {
+func (l LogicImpl) OnPing(_ context.Context, _ *Client, bidi protocol.ProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgPing]) error {
 	return bidi.Write(pb.MsgType_MSG_TYPE_PONG, &pb.MsgPong{
 		SentTs: time.Now().Unix(),
 	})
 }
 
-func (l LogicImpl) OnOpenOutboundProxy(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgOpenOutboundProxy]) error {
+func (l LogicImpl) OnOpenOutboundProxy(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgOpenOutboundProxy]) error {
 	// Validate username.
 	targetUsername, usernameValid := common.NormalizeUsername(msg.Payload.TargetUsername)
 	if !usernameValid {
-		bidi.Stream.CancelRead(protocol.ProxyPeerUnreachableStreamErrorCode)
+		bidi.CancelRead(uint64(protocol.ProxyPeerUnreachableStreamErrorCode))
 		return nil
 	}
 
@@ -189,7 +189,7 @@ func (l LogicImpl) OnOpenOutboundProxy(_ context.Context, client *Client, bidi p
 	return proxy.Run()
 }
 
-func (l LogicImpl) OnGetOnlineUsers(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetOnlineUsers]) error {
+func (l LogicImpl) OnGetOnlineUsers(_ context.Context, client *Client, bidi protocol.ProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetOnlineUsers]) error {
 	const pageSize = 50
 
 	// Snapshot clients and get their statuses.
@@ -223,7 +223,7 @@ func (l LogicImpl) OnGetOnlineUsers(_ context.Context, client *Client, bidi prot
 	return nil
 }
 
-func (l LogicImpl) OnAdvertiseConnMethod(ctx context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgAdvertiseConnMethod]) error {
+func (l LogicImpl) OnAdvertiseConnMethod(ctx context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgAdvertiseConnMethod]) error {
 	ad := msg.Payload
 
 	// Validate address.
@@ -321,7 +321,7 @@ func (l LogicImpl) OnAdvertiseConnMethod(ctx context.Context, client *Client, bi
 	return nil
 }
 
-func (l LogicImpl) OnRemoveConnMethod(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgRemoveConnMethod]) error {
+func (l LogicImpl) OnRemoveConnMethod(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgRemoveConnMethod]) error {
 	client.mu.Lock()
 	_, has := client.connMethods[msg.Payload.Id]
 	if !has {
@@ -334,7 +334,7 @@ func (l LogicImpl) OnRemoveConnMethod(_ context.Context, client *Client, bidi pr
 	return bidi.WriteAck()
 }
 
-func (l LogicImpl) OnGetPublicIp(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetPublicIp]) error {
+func (l LogicImpl) OnGetPublicIp(_ context.Context, client *Client, bidi protocol.ProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetPublicIp]) error {
 	remote := client.RemoteAddr().String()
 
 	var addr string
@@ -349,7 +349,7 @@ func (l LogicImpl) OnGetPublicIp(_ context.Context, client *Client, bidi protoco
 	})
 }
 
-func (l LogicImpl) OnGetClientConnMethods(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgGetClientConnMethods]) error {
+func (l LogicImpl) OnGetClientConnMethods(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgGetClientConnMethods]) error {
 	username, usernameOk := common.NormalizeUsername(msg.Payload.Username)
 	if !usernameOk {
 		return bidi.WriteError(pb.ErrType_ERR_TYPE_INVALID_FIELDS, "invalid username")
@@ -365,7 +365,7 @@ func (l LogicImpl) OnGetClientConnMethods(_ context.Context, client *Client, bid
 	})
 }
 
-func (l LogicImpl) OnGetDirectConnHandshakeToken(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgGetDirectConnHandshakeToken]) error {
+func (l LogicImpl) OnGetDirectConnHandshakeToken(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgGetDirectConnHandshakeToken]) error {
 	target, usernameOk := common.NormalizeUsername(msg.Payload.Username)
 	if !usernameOk {
 		return bidi.WriteError(pb.ErrType_ERR_TYPE_INVALID_FIELDS, "invalid target username")
@@ -379,14 +379,14 @@ func (l LogicImpl) OnGetDirectConnHandshakeToken(_ context.Context, client *Clie
 	})
 }
 
-func (l LogicImpl) OnRedeemConnHandshakeToken(_ context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgRedeemConnHandshakeToken]) error {
+func (l LogicImpl) OnRedeemConnHandshakeToken(_ context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgRedeemConnHandshakeToken]) error {
 	return bidi.Write(
 		pb.MsgType_MSG_TYPE_REDEEM_CONN_HANDSHAKE_TOKEN_RESULT,
 		client.Room.TokenManager.Redeem(client.Username, msg.Payload.Token),
 	)
 }
 
-func (l LogicImpl) OnChangeAccountPassword(ctx context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgChangeAccountPassword]) error {
+func (l LogicImpl) OnChangeAccountPassword(ctx context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgChangeAccountPassword]) error {
 	curPass := msg.Payload.CurrentPassword
 	newPass := msg.Payload.NewPassword
 
@@ -410,7 +410,7 @@ func (l LogicImpl) OnChangeAccountPassword(ctx context.Context, client *Client, 
 	return bidi.WriteAck()
 }
 
-func (l LogicImpl) OnSearch(ctx context.Context, client *Client, bidi protocol.QuicProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgSearch]) error {
+func (l LogicImpl) OnSearch(ctx context.Context, client *Client, bidi protocol.ProtoBidi, msg *protocol.TypedProtoMsg[*pb.MsgSearch]) error {
 	if msg.Payload.Query == "" {
 		return bidi.WriteError(pb.ErrType_ERR_TYPE_INVALID_FIELDS, "query cannot be empty")
 	}
@@ -516,7 +516,7 @@ recvLoop:
 	return nil
 }
 
-func (l LogicImpl) OnGetStunServers(ctx context.Context, client *Client, bidi protocol.QuicProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetStunServers]) error {
+func (l LogicImpl) OnGetStunServers(ctx context.Context, client *Client, bidi protocol.ProtoBidi, _ *protocol.TypedProtoMsg[*pb.MsgGetStunServers]) error {
 	var m = &pb.MsgStunServers{
 		Addresses: l.stunAddrs,
 	}

--- a/server/room/proxy.go
+++ b/server/room/proxy.go
@@ -27,8 +27,8 @@ type ClientProxy struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 
-	originBidi protocol.QuicProtoBidi
-	targetBidi protocol.QuicProtoBidi
+	originBidi protocol.ProtoBidi
+	targetBidi protocol.ProtoBidi
 }
 
 // NewClientProxy creates a new ClientProxy from an existing origin bidi.
@@ -43,7 +43,7 @@ func NewClientProxy(
 	room *Room,
 	originUsername common.NormalizedUsername,
 	targetUsername common.NormalizedUsername,
-	originBidi protocol.QuicProtoBidi,
+	originBidi protocol.ProtoBidi,
 ) (*ClientProxy, error) {
 	targetClient, isOnline := room.GetClientByUsername(targetUsername)
 	if !isOnline {
@@ -99,8 +99,8 @@ func (p *ClientProxy) Close() error {
 	return fmt.Errorf("closing proxy bidi streams failed: %w", errors.Join(errs...))
 }
 
-func (p *ClientProxy) proxyThread(from protocol.QuicProtoBidi, to protocol.QuicProtoBidi) error {
-	_, err := io.Copy(to.Stream, from.Stream)
+func (p *ClientProxy) proxyThread(from protocol.ProtoBidi, to protocol.ProtoBidi) error {
+	_, err := io.Copy(to.RawWriter(), from.RawReader())
 	return err
 }
 

--- a/server/room/room.go
+++ b/server/room/room.go
@@ -226,7 +226,7 @@ func (r *Room) Broadcast(typ pb.MsgType, msg proto.Message) {
 // If there is an existing client with the username, returns ErrUsernameAlreadyConnected.
 // This method will not close the connection if it returns an error; it is the caller's responsibility to close it if an error is returned.
 func (r *Room) Onboard(
-	authBidi protocol.QuicProtoBidi,
+	authBidi protocol.ProtoBidi,
 	conn protocol.ProtoConn,
 	version *pb.ProtoVersion,
 	username common.NormalizedUsername,


### PR DESCRIPTION
Involves sorting direct conns by RTT and falling back onto C2C proxy for most messages if direct conns are taking too long. 